### PR TITLE
Update rekor to latest in v0.4.0

### DIFF
--- a/helm-charts/rekor/values.yaml
+++ b/helm-charts/rekor/values.yaml
@@ -110,7 +110,7 @@ server:
   image:
     repository: gcr.io/projectsigstore/rekor-server
     pullPolicy: IfNotPresent
-    version: "sha256:3dadc6f0d718c9aab3beefec2131713b52af89c280aa460220fa2a7ec5ca4205"
+    version: "sha256:726ae4de825447ec74420f72ca2e17f906e6591240802f5e85b0dc340ed163b3"
   logging:
     production: false
   ingress:


### PR DESCRIPTION
Signed-off-by: Luiz Carvalho <lucarval@redhat.com>

The current image being used has [not been updated](https://console.cloud.google.com/gcr/images/projectsigstore/GLOBAL/rekor-server) since July 28th 2021 which misses more recent features like support for `hashedrekord`.

#### Summary
Update the rekor-server image to the current image referenced by the `v0.4.0` tag.

#### Release Note
```release-note
- Updated rekor-server image to version v0.4.0
```
