### PR TITLE
Update rekor to latest in 0.6.0

### DIFF
--- a/helm-charts/rekor/values.yaml
+++ b/helm-charts/rekor/values.yaml
@@ -110,7 +110,7 @@ server:
   image:
     repository: gcr.io/projectsigstore/rekor-server
     pullPolicy: IfNotPresent
-    version: "sha256:726ae4de825447ec74420f72ca2e17f906e6591240802f5e85b0dc340ed163b3"
+    version: "sha256:f0e178b838bd2da4dae5b56fc8d6d084ac90dbda8e72a91a64b3c956c4620a7c"
   logging:
     production: false
   ingress:


### PR DESCRIPTION
Signed-off-by: Rob Nester <rnester@redhat.com>

Updating the version of rekor to reflect latest version, 0.6.0, which features api updates and other feature enhancements

#### Summary
Update the rekor-server image to the current image referenced by the `v0.6.0` tag.


#### Release Note
```release-note
- Updated rekor-server image to version v0.6.0
```
