### PR TITLE
Update helm chart image values to match dockerfile

### DIFF
--- a/helm-charts/rekor/values.yaml
+++ b/helm-charts/rekor/values.yaml
@@ -50,7 +50,7 @@ mysql:
   image:
     repository: gcr.io/trillian-opensource-ci/db_server
     pullPolicy: IfNotPresent
-    version: "df474653733c51ed91d60cf3efee69f7bf3199bd"
+    version: v1.4.0
   resources: {}
   args:
     - "--ignore-db-dir=lost+found"
@@ -176,9 +176,9 @@ trillianLogServer:
   name: trillian-log-server
   port: 8091
   image:
-    repository: gcr.io/trillian-opensource-ci/log_server
+    repository: gcr.io/projectsigstore/trillian_log_server
     pullPolicy: IfNotPresent
-    version: "df474653733c51ed91d60cf3efee69f7bf3199bd"
+    version: "sha256:f850a0defd089ea844822030c67ae05bc93c91168a7dd4aceb0b6648c39f696b"
   service:
     type: ClusterIP
     ports:
@@ -203,9 +203,9 @@ trillianLogSigner:
   replicaCount: 1
   name: trillian-log-signer
   image:
-    repository: gcr.io/trillian-opensource-ci/log_signer
+    repository: gcr.io/projectsigstore/trillian_log_signer
     pullPolicy: IfNotPresent
-    version: "df474653733c51ed91d60cf3efee69f7bf3199bd"
+    version: "sha256:fe90d523f6617974f70878918e4b31d49b2b46a86024bb2d6b01d2bbfed8edbf"
   service:
     type: ClusterIP
     ports:


### PR DESCRIPTION
This commit updates the image references for the mysql, trillian log
server, and trillian log signer to reflect the same values as present in
the corresponding v0.6.0 docker-compose.yaml file in the rekor
repository.

Signed-off-by: Rob Nester <rnester@redhat.com>

#### Summary
Updates the image version references for mysql, trillian log server and trillian log signer to match those from the docker-compose.yaml in the rekor repository

#### Release Note
```
- Updated mysql, trillian log server, and trillian log signer image versions to match values from rekor v0.6.0 docker-compose.yaml from the rekor repository.
```
